### PR TITLE
Force TERM as xterm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,12 +28,13 @@ RUN apt-get update && \
     mkdir /var/run/sshd && \
     echo -e 'LANG=C.UTF-8\nLC_ALL=C.UTF-8' > /etc/default/locale
 
-RUN adduser --home /home/scanneroperator --disabled-login --gecos "" --shell $(which odoo-sentinel) scanneroperator \
+RUN adduser --home /home/scanneroperator --disabled-login --gecos "" --shell /usr/bin/odoo-sentinel-shell.sh scanneroperator \
     && mkdir /home/scanneroperator/.ssh \
     && chown -R scanneroperator: /home/scanneroperator/.ssh \
     # ignore locale of the ssh client (LANG + LC_*)
     && sed -i '/AcceptEnv LANG LC_*/s/^/#/' /etc/ssh/sshd_config
 
+COPY odoo-sentinel-shell.sh /usr/bin/
 COPY docker-entrypoint.sh /docker-entrypoint.sh
 
 EXPOSE 22

--- a/odoo-sentinel-shell.sh
+++ b/odoo-sentinel-shell.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+# force to xterm because of bogus terminal emulator clients
+export TERM=xterm
+exec odoo-sentinel


### PR DESCRIPTION
We have had terminal emulator on a windows scanning device that sends a
TERM=XTERM (yes uppercase), which is not tolerated by curses.

Forcing to xterm should work for all terminal emulators.